### PR TITLE
feat(widgets-adapter): override default error message with i18n key f…

### DIFF
--- a/packages/widgets-adapter/src/services/esidocService.ts
+++ b/packages/widgets-adapter/src/services/esidocService.ts
@@ -42,7 +42,7 @@ async function get(
     if (!response.ok) {
       const errorPayload = await response.text()
       const errorStatus = response.status
-      if (errorPayload === 'interconnexion esidoc/ENT invalide' && errorStatus === 400) {
+      if (errorStatus === 400 && errorPayload === 'interconnexion esidoc/ENT invalide') {
         return 'I18N$interconnexionEsidocENTinvalide$'
       }
       throw new Error(response.statusText)


### PR DESCRIPTION
…or ESIDOC interconnexion error

## 📝 Pull Request Description

### Brief description of changes applied
Override default message for ESIDOC interconnexion  error in widget adapter by returning a widget marked as in error with an i18n key as error message instead of throwing an exception and letting the wrapper handling it with default message.

### Target Branch
main


